### PR TITLE
Replace SHA-1 CSR checksum algorithm by SHA-2

### DIFF
--- a/darkknight/forms.py
+++ b/darkknight/forms.py
@@ -91,7 +91,7 @@ class GenerateForm(forms.Form):
         if cn.startswith(WWW):
             cn = cn[len(WWW):]
 
-        req.sign(pkey, "sha1")
+        req.sign(pkey, "sha256")
 
         key = crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey)
         csr = crypto.dump_certificate_request(crypto.FILETYPE_PEM, req)


### PR DESCRIPTION
At the date of this commit, all major browsers editors have announced to
drop support for SHA-1 certificate signing before 2017.

Microsoft[1] announced in November 2013 that they will drop their
support in January 2016.

At the same time, a bug was opened on Mozilla's bugzilla to drop support
in January 2017.[2]

In September 2014, Google[3] announced an aggressive deprecation of
SHA-1. SHA-1 signed certificate will be displayed to the user as
"insecure" starting from the first quarter of 2015.

[1] http://blogs.technet.com/b/pki/archive/2013/11/12/sha1-deprecation-policy.aspx
[2] https://bugzil.la/942515
[3] http://googleonlinesecurity.blogspot.com.es/2014/09/gradually-sunsetting-sha-1.html
